### PR TITLE
fix: make sure that the start & end fields exist

### DIFF
--- a/extensions/appworks/README.zh-CN.md
+++ b/extensions/appworks/README.zh-CN.md
@@ -25,7 +25,7 @@ AppWorks 的代码自动补全能力基于语言语义和源代码分析，完�
 
 ### 可视化开发
 
-AppWorks 提供海量物料和可视化消费物料的方式提升多端应用的开发效率。
+AppWorks 提供海量的物料和可视化消费物料的方式提升多端应用的开发效率。
 
 例如，你可以使用模板快速创建项目；可以使用物料面板，将一些精品物料添加到项目当中。
 
@@ -38,7 +38,7 @@ AppWorks 提供海量物料和可视化消费物料的方式提升多端应用�
 AppWorks 编码质效当前提供了两个基本功能：质量检查修复和编程时间管理。
 
 我们基于大量的企业级项目实践，产出了质量评估模型，它能够为项目生成质量报告，并提供了修复相关质量问题的方法。
-编程时间管理则是通过自动跟踪开发者的编程活动从而度量开发者编程效率的功能，它能够帮助开发者回顾自己的编程活动，生成编程效率报告并给予相关的提效建议。
+编程时间管理则是通过自动跟踪开发者的编码活动从而度量开发者编码效率的功能，它能够帮助开发者回顾自己的编码活动，生成编码效率报告并给予相关的提效建议。
 
 ![Doctor](https://img.alicdn.com/imgextra/i4/O1CN01FNcqIN1orpTya1lj8_!!6000000005279-2-tps-746-387.png)
 
@@ -64,7 +64,7 @@ AppWorks 套件内包含以下插件：
 [组件开发辅助](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-material-helper) | 更快更好地添加组件、编写组件属性 | ![Version](https://vsmarketplacebadge.apphb.com/version-short/iceworks-team.iceworks-material-helper.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/iceworks-team.iceworks-material-helper.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-material-helper)
 [代码更新辅助](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-codemod) | 一个帮助您进行大规模代码库重构的工具，这些重构是自动化的，但也提供了人为监督和偶尔干预的方式。 | ![Version](https://vsmarketplacebadge.apphb.com/version-short/iceworks-team.iceworks-codemod.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/iceworks-team.iceworks-codemod.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-codemod)
 [质量检测](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-doctor) | 安全和质量审核工具，快速检测到应用程序和基础库代码中的各种安全漏洞和质量问题 | ![Version](https://vsmarketplacebadge.apphb.com/version-short/iceworks-team.doctor.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/iceworks-team.doctor.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.doctor)
-[时间管理](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-time-master) | 通过自动跟踪您的编程活动从而度量您的编程效率 | ![Version](https://vsmarketplacebadge.apphb.com/version-short/iceworks-team.iceworks-time-master.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/iceworks-team.iceworks-time-master.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-time-master)
+[时间管理](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-time-master) | 通过自动跟踪您的编码活动从而度量您的编码效率 | ![Version](https://vsmarketplacebadge.apphb.com/version-short/iceworks-team.iceworks-time-master.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/iceworks-team.iceworks-time-master.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-time-master)
 [代码重构](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-refactor) | 更简单地重构你的 React / Rax 组件 | ![Version](https://vsmarketplacebadge.apphb.com/version-short/iceworks-team.iceworks-refactor.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/iceworks-team.iceworks-refactor.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-refactor)
 
 ## 获取帮助

--- a/extensions/time-master/CHANGELOG.md
+++ b/extensions/time-master/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0
 
-Release 1.0.0
+- fix: make sure that the start & end fields exist
 
 ## 0.4.6
 

--- a/extensions/time-master/README.zh-CN.md
+++ b/extensions/time-master/README.zh-CN.md
@@ -7,29 +7,34 @@
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-short/iceworks-team.iceworks-time-master.svg)](https://marketplace.visualstudio.com/items?itemName=iceworks-team.iceworks-time-master)
 [![The MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
-时间管理大师是通过自动跟踪您编程活动从而度量您编程效率的插件，它能够帮助您回顾您的编程活动，生成您的编程效率报告并提供相关建议。
+时间管理大师是通过自动跟踪您编码活动从而度量您编码效率的插件，它能够帮助您回顾您的编码活动，生成您的编码效率报告并提供相关建议。
 
-时间管理大师插件不依赖网络环境，安全且轻量，代码开源。
+时间管理大师插件不依赖网络环境，安全轻量，代码开源。
 
 ## 功能
 
-### 了解您的编程活动
+### 了解您的编码活动
 
-![了解编程活动](https://img.alicdn.com/imgextra/i1/O1CN01abIlJ91ec7lgf4uHp_!!6000000003891-2-tps-2880-1754.png)
+![了解编码活动](https://img.alicdn.com/imgextra/i1/O1CN01abIlJ91ec7lgf4uHp_!!6000000003891-2-tps-2880-1754.png)
 
-### 生成您的编程报告
+### 生成您的编码报告
 
-![生成编程报告](https://img.alicdn.com/imgextra/i2/O1CN01kswdUu20kINbuflaj_!!6000000006887-2-tps-2880-1754.png)
+![生成编码报告](https://img.alicdn.com/imgextra/i2/O1CN01kswdUu20kINbuflaj_!!6000000006887-2-tps-2880-1754.png)
 
 ## 安全和隐私
 
-面向社区开发者，时间管理大师插件是完全本地化的，从不访问网络。
+我们向您保证，编码行为追踪功能：
 
-**我们从不访问您的代码**：我们不处理、发送或存储您的代码。插件是开源的，您可以很容易地看到我们的数据处理逻辑。
+- **从不访问网络（备注 1）**：该功能是完全本地化的，从不访问网络。
+- **从不访问您的代码**：我们不处理、发送或存储您的代码。
+- **您的数据是私有的（备注 2）**：我们不会与任何人共享您的个人数据。
 
-**您的数据是私有的**：我们永远不会与任何人共享您的个人数据。
+最重要的一点，插件代码是[开源](https://github.com/appworks-lab/pack/tree/master/extensions/iceworks-time-master)的，您可以很容易地看到我们对于数据处理的实现。
 
-> 在阿里巴巴内网环境下插件将上传编程活动数据，这为我们了解员工的工作健康度、提升员工的工作效率提供数据依据。
+> 备注 1：这是针对社区开发者而言的，如果您是阿里内部用户，我们将默认上传您的数据。
+> 备注 2：我们的内部网站正在补充权限能力，当前他人可能可以通过该方式访问到您的个人数据。
+> 
+> 上传数据的目的是了解员工的工作健康度、为提升员工的工作效率提供数据依据。
 
 ## 更多
 

--- a/extensions/time-master/package.nls.zh-cn.json
+++ b/extensions/time-master/package.nls.zh-cn.json
@@ -3,7 +3,7 @@
   "timeMaster.configuration.properties.appworks.timeLimit.title": "统计数据的保存时长（天数）",
   "timeMaster.configuration.properties.appworks.timeLimit.description": "时间越长，占用本地磁盘容量越多",
   "timeMaster.configuration.properties.appworks.enableView.title": "是否显示视图",
-  "timeMaster.configuration.properties.appworks.enableView.description": "在侧边栏显示编程活动数据",
+  "timeMaster.configuration.properties.appworks.enableView.description": "在侧边栏显示编码活动数据",
   "timeMaster.configuration.properties.appworks.enableStatusBar.title": "是否显示状态栏",
   "timeMaster.configuration.properties.appworks.enableStatusBar.description": "在窗口右下角的状态栏显示编辑器使用时间"
 }

--- a/extensions/time-master/src/locales/zh-CN.json
+++ b/extensions/time-master/src/locales/zh-CN.json
@@ -29,7 +29,7 @@
   "extension.timeMaster.linesRemoved": "删除的代码行数",
   "extension.timeMaster.keystrokes": "总的键入数",
   "extension.timeMaster.separator": "：",
-  "extension.timeMaster.viewUserSummary.label": "查看编程活动报告",
+  "extension.timeMaster.viewUserSummary.label": "查看编码活动报告",
   "extension.timeMaster.viewUserSummary.detail": "",
   "extension.timeMaster.viewProjectSummary.label": "查看项目开发报告",
   "extension.timeMaster.viewProjectSummary.detail": ""

--- a/extensions/time-master/src/recorders/keystrokeStats/keystrokeStats.ts
+++ b/extensions/time-master/src/recorders/keystrokeStats/keystrokeStats.ts
@@ -172,8 +172,12 @@ export class KeystrokeStats {
 
   deactivate() {
     this.setEnd();
-    forIn(this.files, (fileChange: FileChange) => {
-      fileChange.deactivate();
+    forIn(this.files, (fileChange: FileChange, key: string) => {
+      if (fileChange.start && fileChange.end) {
+        fileChange.deactivate();
+      } else {
+        delete this.files[key];
+      }
     });
   }
 }


### PR DESCRIPTION
为了能够更快地获取文件信息，fileChange 对象是 `onDidOpenTextDocument` 那一刻创建的；
如果没有触发 `onDidChangeTextDocument` ，则对象会没有经历 `setStart` 和 `setEnd`，因此 `start` 和 `end` 字段为空。
在发送 `KeystrokeStats` 到数据处理器时，需要确保所有 fileChange 对象都是确实 `changed`，否则数据库内会有 start/end 为 0 的记录。