### PR TITLE
feat: loading status when reinstalling deps

### DIFF
--- a/extensions/application-manager/CHANGELOG.md
+++ b/extensions/application-manager/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.2
 
+- feat: add loading status when reinstalling dependencies
 - chore: update @appworks/recorder version
 
 ## 1.0.1

--- a/extensions/application-manager/src/locales/en-US.json
+++ b/extensions/application-manager/src/locales/en-US.json
@@ -51,5 +51,6 @@
   "extension.applicationManager.extension.emptyWorkplace": "Current workspace is empty, please open or create an application.",
   "extension.applicationManager.hintInstallTypesrax.message": "Detected that you did not have @types/rax installed. For better code tips, it is recommended that you install.",
   "extension.applicationManager.hintInstallTypesrax.message.install": "Install",
-  "extension.applicationManager.hintInstallTypesrax.message.ignore": "Ignore"
+  "extension.applicationManager.hintInstallTypesrax.message.ignore": "Ignore",
+  "extension.applicationManager.nodeDependencies.delete.title": "Deleting <%= nodeModulesPath %>"
 }

--- a/extensions/application-manager/src/locales/zh-CN.json
+++ b/extensions/application-manager/src/locales/zh-CN.json
@@ -50,5 +50,6 @@
   "extension.applicationManager.dashboard.extension.webviewTitle": "项目仪表盘 - AppWorks",
   "extension.applicationManager.hintInstallTypesrax.message": "检测到您未安装 @types/rax。为获得更好的代码提示，建议您安装。",
   "extension.applicationManager.hintInstallTypesrax.message.install": "安装",
-  "extension.applicationManager.hintInstallTypesrax.message.ignore": "忽略"
+  "extension.applicationManager.hintInstallTypesrax.message.ignore": "忽略",
+  "extension.applicationManager.nodeDependencies.delete.title": "正在删除 <%= nodeModulesPath %>"
 }

--- a/extensions/application-manager/src/views/nodeDependenciesView.ts
+++ b/extensions/application-manager/src/views/nodeDependenciesView.ts
@@ -231,7 +231,7 @@ export function createNodeDependenciesTreeView(context) {
       if (nodeModulesExists) {
         await vscode.window.withProgress({
           location: vscode.ProgressLocation.Notification,
-          title: `Deleting ${nodeModulesPath}`,
+          title: i18n.format('extension.applicationManager.nodeDependencies.delete.title', { nodeModulesPath }),
         }, async () => {
           try {
             await rimrafAsync(nodeModulesPath);

--- a/extensions/application-manager/src/views/nodeDependenciesView.ts
+++ b/extensions/application-manager/src/views/nodeDependenciesView.ts
@@ -34,7 +34,7 @@ class DepNodeProvider implements vscode.TreeDataProvider<ItemData> {
 
   readonly onDidChangeTreeData: vscode.Event<ItemData | undefined> = this.onDidChange.event;
 
-  public packageJsonPath: string;
+  packageJsonPath: string;
 
   constructor(context: vscode.ExtensionContext, workspaceRoot: string) {
     this.extensionContext = context;
@@ -106,7 +106,7 @@ class DepNodeProvider implements vscode.TreeDataProvider<ItemData> {
     return item;
   }
 
-  public async buildDepsChildItems(nodeDepType: NodeDepTypes) {
+  async buildDepsChildItems(nodeDepType: NodeDepTypes) {
     let depItems: ItemData[] = [];
     if (this.workspaceRoot && await checkPathExists(this.packageJsonPath)) {
       const packageJson = await fse.readJSON(this.packageJsonPath);
@@ -180,7 +180,7 @@ class DepNodeProvider implements vscode.TreeDataProvider<ItemData> {
     return items;
   }
 
-  public getAddDependencyScript(depType: NodeDepTypes, packageName: string) {
+  getAddDependencyScript(depType: NodeDepTypes, packageName: string) {
     const workspaceDir: string = path.dirname(this.packageJsonPath);
     const isYarn = isYarnPackageManager();
     const isDevDep = depType === 'devDependencies';
@@ -227,8 +227,19 @@ export function createNodeDependenciesTreeView(context) {
     if (await checkPathExists(nodeDependenciesProvider.packageJsonPath)) {
       const workspaceDir: string = path.dirname(nodeDependenciesProvider.packageJsonPath);
       const nodeModulesPath = path.join(workspaceDir, 'node_modules');
-      if (await checkPathExists(nodeModulesPath)) {
-        await rimrafAsync(nodeModulesPath);
+      const nodeModulesExists = await checkPathExists(nodeModulesPath);
+      if (nodeModulesExists) {
+        await vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `Deleting ${nodeModulesPath}`,
+        }, async () => {
+          try {
+            await rimrafAsync(nodeModulesPath);
+          } catch (error) {
+            vscode.window.showErrorMessage(`Fail to delete ${nodeModulesPath}. Error: ${error.message}.`);
+          }
+          return Promise.resolve();
+        });
       }
       const command = createNpmCommand('install');
       const title = 'Reinstall Dependencies';


### PR DESCRIPTION
背景：点击“重装依赖”，会先删除 node_modules 目录，然后进行 npm install。但删除 node_modules 的过程中没有任何提示货反馈，需要增加 loading 的状态以获得更好的用户体验。

Preview:
![2021-07-06 13-19-07 2021-07-06 13_19_39](https://user-images.githubusercontent.com/44047106/124546429-35bf8200-de5d-11eb-92a3-83ee138ad474.gif)
