### PR TITLE
Fix overrides files not work

### DIFF
--- a/extensions/doctor/CHANGELOG.md
+++ b/extensions/doctor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+
+## 1.1.2
+
+- feat: update @appworks/doctor to support custom config set extends and plugins.
 ## 1.1.1
 
 - fix: empty project show wrong CodeMod notice.

--- a/extensions/doctor/package.json
+++ b/extensions/doctor/package.json
@@ -3,7 +3,7 @@
   "displayName": "Doctor",
   "description": "A free security and quality audit tool for modern DevOps teams",
   "publisher": "iceworks-team",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "engines": {
     "vscode": "^1.41.0"
   },
@@ -82,7 +82,7 @@
     "@appworks/common-service": "^0.1.0",
     "@appworks/connector": "^0.1.0",
     "@appworks/constant": "^0.1.0",
-    "@appworks/doctor": "^0.2.0",
+    "@appworks/doctor": "^0.2.1",
     "@appworks/project-service": "^0.1.0",
     "@appworks/recorder": "^0.1.0",
     "@appworks/storage": "^0.1.0",

--- a/packages/doctor/CHANGELOG.md
+++ b/packages/doctor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.2.1
+
+- Support custom config set extends and plugins.
+
 ## 0.2.0
 
 - Remove codemod CLI usage.

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appworks/doctor",
   "description": "Analyse and running codemods over react/rax projects, troubleshooting and automatically fixing errors",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": [
     "doctor",
     "analysis",

--- a/packages/doctor/src/workers/eslint/getEslintReports.ts
+++ b/packages/doctor/src/workers/eslint/getEslintReports.ts
@@ -43,7 +43,9 @@ export default function getEslintReports(directory: string, files: IFileInfo[], 
   const cliEngine = new CLIEngine({
     cache: false,
     baseConfig: deepmerge(getESLintConfig(ruleKey), customConfig),
-    cwd: path.dirname(require.resolve('@iceworks/spec')),
+    cwd: directory,
+    // If user add extends or plugins, should find plugin form target directory
+    resolvePluginsRelativeTo: customConfig.extends || customConfig.plugins ? directory : path.dirname(require.resolve('@iceworks/spec')),
     fix: !!fixErr,
     useEslintrc: false,
   });


### PR DESCRIPTION
* Support add extends and plugins config.
* Fix overrides files not work,  like:
  ```javascript
  const { getESLintConfig } = require('@iceworks/spec');
  
  module.exports = getESLintConfig('react-ts', {
    overrides: [
      {
        files: ['**/src/apis/**'],
        rules: {
          'react-hooks/rules-of-hooks': 0,
        },
      },
    ]
  });
  ```
Because cwd is not current project path.


