### PR TITLE
Fix: dashboard error

### DIFF
--- a/extensions/application-manager/CHANGELOG.md
+++ b/extensions/application-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.3
+
+- fix: can not get project info in dashboard when in external
+
 ## 1.0.2
 
 - feat: add loading status when reinstalling dependencies

--- a/extensions/application-manager/package.json
+++ b/extensions/application-manager/package.json
@@ -3,7 +3,7 @@
   "displayName": "Application Manager",
   "description": "Quick view your Universal Application(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/application-manager/web/src/pages/Dashboard/models/info.ts
+++ b/extensions/application-manager/web/src/pages/Dashboard/models/info.ts
@@ -14,9 +14,11 @@ export default {
   effects: () => ({
     async refresh() {
       this.setState({ inited: true });
-      const basic = await callService('project', 'getProjectBaseInfo');
-      const git = await callService('project', 'getProjectGitInfo');
-      const def = await callService('project', 'getProjectDefInfo', CLIENT_TOKEN);
+      const [basic, git, def] = await Promise.all([
+        await callService('project', 'getProjectBaseInfo'),
+        await callService('project', 'getProjectGitInfo'),
+        await callService('project', 'getProjectDefInfo', CLIENT_TOKEN),
+      ]);
       this.setState({
         basic,
         git,

--- a/packages/project-service/CHANGELOG.md
+++ b/packages/project-service/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.1.2
+
+- fix: fail to execute getProjectDefInfo function in external
+- fix: check latest package version too slow
+
 ## 0.1.1
 
 - fix: rax-spa project targets null problem. [#861](https://github.com/appworks-lab/pack/issues/861)

--- a/packages/project-service/package.json
+++ b/packages/project-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appworks/project-service",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AppWorks project service for VSCode extension.",
   "files": [
     "lib"
@@ -15,7 +15,6 @@
     "@appworks/recorder": "^0.1.0",
     "@appworks/i18n": "^0.1.0",
     "@appworks/constant": "^0.1.0",
-    "latest-version": "^5.1.0",
     "package-json": "^6.5.0",
     "ice-npm-utils": "^2.0.0",
     "axios": "^0.19.2",
@@ -23,7 +22,6 @@
     "simple-git": "^2.5.0"
   },
   "devDependencies": {
-    "@types/latest-version": "^4.0.1",
     "@types/vscode": "^1.45.0"
   },
   "publishConfig": {

--- a/packages/project-service/src/dependency.ts
+++ b/packages/project-service/src/dependency.ts
@@ -1,15 +1,14 @@
 import { getProjectFramework } from '@appworks/project-utils';
 import { getPackageLocalVersion } from 'ice-npm-utils';
-import latestVersion from 'latest-version';
 // import * as fsExtra from 'fs-extra';
 // import * as path from 'path';
 import { getDataFromSettingJson } from '@appworks/common-service';
-import packageJSON from 'package-json';
+import packageJSON, { AbbreviatedMetadata } from 'package-json';
 import { projectPath } from './constant';
 import { getProjectPackageJSON } from './utils';
 
 export async function getCoreDependencies() {
-  const framwork = await getProjectFramework(projectPath);
+  const framework = await getProjectFramework(projectPath);
   const iceCoreDeps = [
     'react', 'ice.js',
   ];
@@ -17,9 +16,9 @@ export async function getCoreDependencies() {
     'rax', 'rax-app',
   ];
   let coreDeps = [];
-  if (framwork === 'rax-app') {
+  if (framework === 'rax-app') {
     coreDeps = raxCoreDeps;
-  } else if (framwork === 'icejs') {
+  } else if (framework === 'icejs') {
     coreDeps = iceCoreDeps;
   }
   async function checkIsCore(packageName) {
@@ -134,9 +133,16 @@ function getLocalDependencyVersion(moduleName: string): string {
   }
 }
 
+interface PackageJSON extends AbbreviatedMetadata {
+  version: string;
+}
+
 async function getNpmOutdated(moduleName: string, version: string, semver: string) {
   try {
-    const latest = await latestVersion(moduleName, { version: semver });
+    const { version: latest } = await packageJSON(
+      moduleName,
+      { version: semver, registryUrl: getDataFromSettingJson('npmRegistry') },
+    ) as PackageJSON;
     return version !== latest ? latest : '';
   } catch (err) {
     return '';

--- a/packages/project-service/src/index.ts
+++ b/packages/project-service/src/index.ts
@@ -1,8 +1,13 @@
 import * as vscode from 'vscode';
 import * as fsExtra from 'fs-extra';
 import { downloadAndGenerateProject } from '@iceworks/generate-project';
-import { checkPathExists, getDataFromSettingJson, CONFIGURATION_KEY_NPM_REGISTRY } from '@appworks/common-service';
-import { checkIsTargetProjectType as orginCheckIsTargetProjectType, checkIsTargetProjectFramework as orginCheckIsTargetProjectFramework, getProjectType as originGetProjectType, getProjectFramework as originGetProjectFramework } from '@appworks/project-utils';
+import { checkPathExists, getDataFromSettingJson, CONFIGURATION_KEY_NPM_REGISTRY, checkIsAliInternal } from '@appworks/common-service';
+import {
+  checkIsTargetProjectType as originCheckIsTargetProjectType,
+  checkIsTargetProjectFramework as originCheckIsTargetProjectFramework,
+  getProjectType as originGetProjectType,
+  getProjectFramework as originGetProjectFramework,
+} from '@appworks/project-utils';
 import * as simpleGit from 'simple-git/promise';
 import { Recorder } from '@appworks/recorder';
 import * as path from 'path';
@@ -37,11 +42,11 @@ export async function autoSetContext() {
 }
 
 export async function checkIsTargetProjectType() {
-  return await orginCheckIsTargetProjectType(projectPath);
+  return await originCheckIsTargetProjectType(projectPath);
 }
 
 export async function checkIsTargetProjectFramework() {
-  return await orginCheckIsTargetProjectFramework(projectPath);
+  return await originCheckIsTargetProjectFramework(projectPath);
 }
 
 export async function getFeedbackLink() {
@@ -96,6 +101,10 @@ export async function getProjectGitInfo() {
 }
 
 export async function getProjectDefInfo(clientToken: string) {
+  const isAliInternal = await checkIsAliInternal();
+  if (!isAliInternal) {
+    return { isDef: false };
+  }
   const { group, project } = await getProjectGitInfo();
   const info = await getBasicInfo(`${group}/${project}`, clientToken);
   return {


### PR DESCRIPTION
Closed: https://github.com/appworks-lab/pack/issues/857

问题：在外网环境下，获取项目信息（基本信息和依赖信息）失败
- 获取依赖信息失败原因是使用 latest-version 获取依赖最新版本太慢了
- 外网环境下获取 def 信息时有请求内网地址，但没有设置超时时间

解决：
- 现在改用 package-json （支持传入 registry 地址）获取依赖最新版本
- 判断是否在外网环境下，如果是，则不去获取 def 信息

